### PR TITLE
Add "blocks" movement and send functions 

### DIFF
--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -1,0 +1,133 @@
+;;; sage-blocks.el --- Support for structuring Sage code in sheets
+
+;; Copyright (C) 2013 Johan S. R. Nielsen
+
+;; Author: Johan S. R. Nielsen <jsrn@jsrn.dk>
+;; Keywords: sage
+
+;;; Commentary:
+
+;; This file adds functionality which supports structuring experimental Sage
+;; code in "sheets", where the code is bundled in "blocks" akin to the boxes of
+;; the Notebook. The core is concerned with convenient handling of such
+;; blocks. The file injects a few keybindings into `sage-mode' as well as
+;; `inferior-sage-mode'.
+
+;; A block is defined by a line beginning with `sage-block-delimiter'.
+
+;;; Code:
+(defcustom sage-block-delimiter "###"
+  "Any line matching the regular expression `sage-block-delimiter' at the
+  beginning of the line is considered a start of a block.
+
+Note that '^' to match at the beginning of the line should not be added to
+`sage-block-delimiter'.
+Strange behaviour might arise if `sage-block-delimiter' matches multiple lines
+at a time."
+  :type 'string
+  :group 'sage)
+
+(defcustom sage-block-title-decorate " ---- "
+  "When printing titles of blocks, put this decoration around the
+title for easy recognition"
+  :type 'string
+  :group 'sage)
+
+;;
+;; Functionality for Sage source files
+;;
+(defun sage-backward-block (arg)
+  "Move backwards to the last beginning of a block."
+  (interactive "p")
+  (if (< arg 0)
+      (sage-forward-block (- arg))
+    (while (and (> arg 0)
+		(search-backward-regexp (concat "^" sage-block-delimiter) nil 'move))
+      (setq arg (- arg 1)))))
+
+(defun sage-forward-block (arg)
+  "Move forwards to the next beginning of a block."
+  (interactive "p")
+  (if (< arg 0)
+      (sage-backward-block (- arg))
+    ;; If point is on a delimiter, we should skip this, so search from beginning of
+    ;; next line (this will match immediately, if next line is a delimiter)
+    (let ((re  (concat "^" sage-block-delimiter)))
+      (when (looking-at re)
+	(forward-line))
+      ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
+      (while (and (> arg 0)
+		  (search-forward-regexp re nil 'move))
+	(setq arg (- arg 1)))
+      ;; We successfully found something so move to the beginning of the match
+      (when (= arg 0)
+	(goto-char (match-beginning 0))))))
+
+(defun sage-send-current-block ()
+  "Send the block that the point is currently in to the inferior shell.
+Move to end of block sent."
+  (interactive)
+  ;; Border-case: if we're standing on a delimiter, sage-backward-block will go
+  ;; to previous delimiter, but we should send from this delimiter and forwards.
+  (sage-forward-block 1)
+  (let* ((this-buf (current-buffer))
+	 (enddelim (point))
+	 (backdelim (save-excursion
+		      (sage-backward-block 1)
+		      (point)))
+	 title)
+    ;; Copy the region to a temp buffer.
+    ;; Possibly change the first line if it contains a title
+    (with-temp-buffer
+      (insert-buffer-substring this-buf backdelim enddelim)
+      (goto-char (point-min))
+      (when (looking-at sage-block-delimiter)
+	(progn
+	  (goto-char (match-end 0))
+	  (setq title (buffer-substring (point)
+					(progn (end-of-line) (point))))
+	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
+	    (setq title (match-string 1 title)))
+	  (unless (equal title "")
+	    (insert (concat "\nprint(\"" sage-block-title-decorate title sage-block-title-decorate "\")")))))
+      (sage-send-region (point-min) (point-max)))))
+
+(defun sage-blocks-default-keybindings ()
+  "Bind default keys for working with sage blocks.
+
+These are
+  C-M-{      `sage-backward-block'
+  C-M-}      `sage-forward-block'
+  C-<return> `sage-send-current-block'
+
+in `sage-mode' and in `inferior-sage-mode-map':
+
+  C-<return> `sage-pull-next-block'"
+  (define-key sage-mode-map (kbd "C-<return>") 'sage-send-current-block)
+  (define-key sage-mode-map (kbd "C-M-{")        'sage-backward-block)
+  (define-key sage-mode-map (kbd "C-M-}")        'sage-forward-block)
+  (define-key inferior-sage-mode-map (kbd "C-<return>") 'sage-pull-next-block))
+
+;;
+;; Functionality for the inferior shell
+;;
+(defun sage-pull-next-block ()
+  "Evaluate the next block of the last visited file in Sage mode."
+  (interactive)
+  ;; Find the first buffer in buffer-list which is in sage-mode
+  (let* ((lst (buffer-list))
+	 (buf
+	  (catch 'break
+	    (while lst
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-mode))
+		  (throw 'break (car lst))
+		(setq lst (cdr lst)))))))
+    (if buf
+	(progn
+	  (switch-to-buffer-other-window buf)
+	  (sage-send-current-block))
+      (error "No sage-mode buffer found"))))
+
+(provide 'sage-blocks)
+
+;;; sage-blocks.el ends here

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -13,21 +13,21 @@
 ;; The file injects a few keybindings into `sage-mode' as well as
 ;; `sage-shell-mode'.
 
-;; A block is defined by a line beginning with `sage-shell:block-delimiter'.
+;; A block is defined by a line beginning with `sage-shell-blocks:delimiter'.
 
 ;;; Code:
-(defcustom sage-shell:block-delimiter "###"
-  "Any line matching the regular expression `sage-shell:block-delimiter' at the
+(defcustom sage-shell-blocks:delimiter "###"
+  "Any line matching the regular expression `sage-shell-blocks:delimiter' at the
   beginning of the line is considered a start of a block.
 
 Note that '^' to match at the beginning of the line should not be added to
-`sage-shell:block-delimiter'.
-Strange behaviour might arise if `sage-shell:block-delimiter' matches multiple lines
+`sage-shell-blocks:delimiter'.
+Strange behaviour might arise if `sage-shell-blocks:delimiter' matches multiple lines
 at a time."
   :type 'string
   :group 'sage)
 
-(defcustom sage-shell:block-title-decorate " ---- "
+(defcustom sage-shell-blocks:title-decorate " ---- "
   "When printing titles of blocks, put this decoration around the
 title for easy recognition"
   :type 'string
@@ -36,23 +36,23 @@ title for easy recognition"
 ;;
 ;; Functionality for Sage source files
 ;;
-(defun sage-shell:backward-block (arg)
+(defun sage-shell-blocks:backward (arg)
   "Move backwards to the last beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-shell:forward-block (- arg))
+      (sage-shell-blocks:forward (- arg))
     (while (and (> arg 0)
-		(search-backward-regexp (concat "^" sage-shell:block-delimiter) nil 'move))
+		(search-backward-regexp (concat "^" sage-shell-blocks:delimiter) nil 'move))
       (setq arg (- arg 1)))))
 
-(defun sage-shell:forward-block (arg)
+(defun sage-shell-blocks:forward (arg)
   "Move forwards to the next beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-shell:backward-block (- arg))
+      (sage-shell-blocks:backward (- arg))
     ;; If point is on a delimiter, we should skip this, so search from beginning of
     ;; next line (this will match immediately, if next line is a delimiter)
-    (let ((re  (concat "^" sage-shell:block-delimiter)))
+    (let ((re  (concat "^" sage-shell-blocks:delimiter)))
       (when (looking-at re)
 	(forward-line))
       ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
@@ -63,17 +63,17 @@ title for easy recognition"
       (when (= arg 0)
 	(goto-char (match-beginning 0))))))
 
-(defun sage-shell:send-current-block ()
+(defun sage-shell-blocks:send-current ()
   "Send the block that the point is currently in to the inferior shell.
 Move to end of block sent."
   (interactive)
-  ;; Border-case: if we're standing on a delimiter, sage-shell:backward-block will go
+  ;; Border-case: if we're standing on a delimiter, sage-shell-blocks:backward will go
   ;; to previous delimiter, but we should send from this delimiter and forwards.
-  (sage-shell:forward-block 1)
+  (sage-shell-blocks:forward 1)
   (let* ((this-buf (current-buffer))
 	 (enddelim (point))
 	 (backdelim (save-excursion
-		      (sage-shell:backward-block 1)
+		      (sage-shell-blocks:backward 1)
 		      (point)))
 	 title)
     ;; Copy the region to a temp buffer.
@@ -81,7 +81,7 @@ Move to end of block sent."
     (with-temp-buffer
       (insert-buffer-substring this-buf backdelim enddelim)
       (goto-char (point-min))
-      (when (looking-at sage-shell:block-delimiter)
+      (when (looking-at sage-shell-blocks:delimiter)
 	(progn
 	  (goto-char (match-end 0))
 	  (setq title (buffer-substring (point)
@@ -89,43 +89,42 @@ Move to end of block sent."
 	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
 	    (setq title (match-string 1 title)))
 	  (unless (equal title "")
-	    (insert (concat "\nprint(\"" sage-shell:block-title-decorate title sage-shell:block-title-decorate "\")")))))
-      (sage-shell:send-region (point-min) (point-max)))))
+	    (insert (concat "\nprint(\"" sage-shell-blocks:title-decorate title sage-shell-blocks:title-decorate "\")")))))
+      (sage-shell-edit:send-region (point-min) (point-max)))))
 
-(defun sage-shell:blocks-default-keybindings ()
+(defun sage-shell-blocks:default-keybindings ()
   "Bind default keys for working with Sage blocks.
 
-The following are added to `sage-mode':
-  C-M-{      `sage-shell:backward-block'
-  C-M-}      `sage-shell:forward-block'
-  C-<return> `sage-shell:send-current-block'
+The following are added to `sage-shell:sage-mode':
+  C-M-{      `sage-shell-blocks:backward'
+  C-M-}      `sage-shell-blocks:forward'
+  C-<return> `sage-shell-blocks:send-current'
 
 The following are added to `sage-shell-mode':
-  C-<return> `sage-shell:pull-next-block'"
-  (define-key sage-shell:mode-map (kbd "C-<return>") 'sage-shell:send-current-block)
-  (define-key sage-shell:mode-map (kbd "C-M-{")        'sage-shell:backward-block)
-  (define-key sage-shell:mode-map (kbd "C-M-}")        'sage-shell:forward-block)
-  (define-key inferior-sage-shell:mode-map (kbd "C-<return>") 'sage-shell:pull-next-block))
+  C-<return> `sage-shell-blocks:pull-next'"
+  (define-key sage-shell:sage-mode-map (kbd "C-<return>") 'sage-shell-blocks:send-current)
+  (define-key sage-shell:sage-mode-map (kbd "C-M-{")      'sage-shell-blocks:backward)
+  (define-key sage-shell:sage-mode-map (kbd "C-M-}")      'sage-shell-blocks:forward)
+  (define-key sage-shell-mode-map (kbd "C-<return>")      'sage-shell-blocks:pull-next))
 
-;;
 ;; Functionality for the inferior shell
 ;;
-(defun sage-shell:pull-next-block ()
+(defun sage-shell-blocks:pull-next ()
   "Evaluate the next block of the last visited file in Sage mode."
   (interactive)
-  ;; Find the first buffer in buffer-list which is in sage-shell-mode
+  ;; Find the first buffer in buffer-list which is in sage-shell:sage-mode
   (let* ((lst (buffer-list))
 	 (buf
 	  (catch 'break
 	    (while lst
-	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell-mode))
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell:sage-mode))
 		  (throw 'break (car lst))
 		(setq lst (cdr lst)))))))
     (if buf
 	(progn
 	  (switch-to-buffer-other-window buf)
-	  (sage-shell:send-current-block))
-      (error "No sage-shell-mode buffer found"))))
+	  (sage-shell-blocks:send-current))
+      (error "No sage-shell:sage-mode buffer found"))))
 
 (provide 'sage-shell-blocks)
 

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -1,33 +1,33 @@
-;;; sage-blocks.el --- Support for structuring Sage code in sheets
+;;; sage-shell-blocks.el --- Support for structuring Sage code in sheets
 
-;; Copyright (C) 2013 Johan S. R. Nielsen
+;; Copyright (C) 2013-2016 Johan Rosenkilde
 
-;; Author: Johan S. R. Nielsen <jsrn@jsrn.dk>
+;; Author: Johan Rosenkilde <jsrn@jsrn.dk>
 ;; Keywords: sage
 
 ;;; Commentary:
 
 ;; This file adds functionality which supports structuring experimental Sage
 ;; code in "sheets", where the code is bundled in "blocks" akin to the boxes of
-;; the Notebook. The core is concerned with convenient handling of such
-;; blocks. The file injects a few keybindings into `sage-mode' as well as
-;; `inferior-sage-mode'.
+;; the Notebook. Functions are provided for convenient handling of such blocks.
+;; The file injects a few keybindings into `sage-mode' as well as
+;; `sage-shell-mode'.
 
-;; A block is defined by a line beginning with `sage-block-delimiter'.
+;; A block is defined by a line beginning with `sage-shell:block-delimiter'.
 
 ;;; Code:
-(defcustom sage-block-delimiter "###"
-  "Any line matching the regular expression `sage-block-delimiter' at the
+(defcustom sage-shell:block-delimiter "###"
+  "Any line matching the regular expression `sage-shell:block-delimiter' at the
   beginning of the line is considered a start of a block.
 
 Note that '^' to match at the beginning of the line should not be added to
-`sage-block-delimiter'.
-Strange behaviour might arise if `sage-block-delimiter' matches multiple lines
+`sage-shell:block-delimiter'.
+Strange behaviour might arise if `sage-shell:block-delimiter' matches multiple lines
 at a time."
   :type 'string
   :group 'sage)
 
-(defcustom sage-block-title-decorate " ---- "
+(defcustom sage-shell:block-title-decorate " ---- "
   "When printing titles of blocks, put this decoration around the
 title for easy recognition"
   :type 'string
@@ -36,23 +36,23 @@ title for easy recognition"
 ;;
 ;; Functionality for Sage source files
 ;;
-(defun sage-backward-block (arg)
+(defun sage-shell:backward-block (arg)
   "Move backwards to the last beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-forward-block (- arg))
+      (sage-shell:forward-block (- arg))
     (while (and (> arg 0)
-		(search-backward-regexp (concat "^" sage-block-delimiter) nil 'move))
+		(search-backward-regexp (concat "^" sage-shell:block-delimiter) nil 'move))
       (setq arg (- arg 1)))))
 
-(defun sage-forward-block (arg)
+(defun sage-shell:forward-block (arg)
   "Move forwards to the next beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-backward-block (- arg))
+      (sage-shell:backward-block (- arg))
     ;; If point is on a delimiter, we should skip this, so search from beginning of
     ;; next line (this will match immediately, if next line is a delimiter)
-    (let ((re  (concat "^" sage-block-delimiter)))
+    (let ((re  (concat "^" sage-shell:block-delimiter)))
       (when (looking-at re)
 	(forward-line))
       ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
@@ -63,17 +63,17 @@ title for easy recognition"
       (when (= arg 0)
 	(goto-char (match-beginning 0))))))
 
-(defun sage-send-current-block ()
+(defun sage-shell:send-current-block ()
   "Send the block that the point is currently in to the inferior shell.
 Move to end of block sent."
   (interactive)
-  ;; Border-case: if we're standing on a delimiter, sage-backward-block will go
+  ;; Border-case: if we're standing on a delimiter, sage-shell:backward-block will go
   ;; to previous delimiter, but we should send from this delimiter and forwards.
-  (sage-forward-block 1)
+  (sage-shell:forward-block 1)
   (let* ((this-buf (current-buffer))
 	 (enddelim (point))
 	 (backdelim (save-excursion
-		      (sage-backward-block 1)
+		      (sage-shell:backward-block 1)
 		      (point)))
 	 title)
     ;; Copy the region to a temp buffer.
@@ -81,7 +81,7 @@ Move to end of block sent."
     (with-temp-buffer
       (insert-buffer-substring this-buf backdelim enddelim)
       (goto-char (point-min))
-      (when (looking-at sage-block-delimiter)
+      (when (looking-at sage-shell:block-delimiter)
 	(progn
 	  (goto-char (match-end 0))
 	  (setq title (buffer-substring (point)
@@ -89,45 +89,44 @@ Move to end of block sent."
 	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
 	    (setq title (match-string 1 title)))
 	  (unless (equal title "")
-	    (insert (concat "\nprint(\"" sage-block-title-decorate title sage-block-title-decorate "\")")))))
-      (sage-send-region (point-min) (point-max)))))
+	    (insert (concat "\nprint(\"" sage-shell:block-title-decorate title sage-shell:block-title-decorate "\")")))))
+      (sage-shell:send-region (point-min) (point-max)))))
 
-(defun sage-blocks-default-keybindings ()
-  "Bind default keys for working with sage blocks.
+(defun sage-shell:blocks-default-keybindings ()
+  "Bind default keys for working with Sage blocks.
 
-These are
-  C-M-{      `sage-backward-block'
-  C-M-}      `sage-forward-block'
-  C-<return> `sage-send-current-block'
+The following are added to `sage-mode':
+  C-M-{      `sage-shell:backward-block'
+  C-M-}      `sage-shell:forward-block'
+  C-<return> `sage-shell:send-current-block'
 
-in `sage-mode' and in `inferior-sage-mode-map':
-
-  C-<return> `sage-pull-next-block'"
-  (define-key sage-mode-map (kbd "C-<return>") 'sage-send-current-block)
-  (define-key sage-mode-map (kbd "C-M-{")        'sage-backward-block)
-  (define-key sage-mode-map (kbd "C-M-}")        'sage-forward-block)
-  (define-key inferior-sage-mode-map (kbd "C-<return>") 'sage-pull-next-block))
+The following are added to `sage-shell-mode':
+  C-<return> `sage-shell:pull-next-block'"
+  (define-key sage-shell:mode-map (kbd "C-<return>") 'sage-shell:send-current-block)
+  (define-key sage-shell:mode-map (kbd "C-M-{")        'sage-shell:backward-block)
+  (define-key sage-shell:mode-map (kbd "C-M-}")        'sage-shell:forward-block)
+  (define-key inferior-sage-shell:mode-map (kbd "C-<return>") 'sage-shell:pull-next-block))
 
 ;;
 ;; Functionality for the inferior shell
 ;;
-(defun sage-pull-next-block ()
+(defun sage-shell:pull-next-block ()
   "Evaluate the next block of the last visited file in Sage mode."
   (interactive)
-  ;; Find the first buffer in buffer-list which is in sage-mode
+  ;; Find the first buffer in buffer-list which is in sage-shell-mode
   (let* ((lst (buffer-list))
 	 (buf
 	  (catch 'break
 	    (while lst
-	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-mode))
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell-mode))
 		  (throw 'break (car lst))
 		(setq lst (cdr lst)))))))
     (if buf
 	(progn
 	  (switch-to-buffer-other-window buf)
-	  (sage-send-current-block))
-      (error "No sage-mode buffer found"))))
+	  (sage-shell:send-current-block))
+      (error "No sage-shell-mode buffer found"))))
 
-(provide 'sage-blocks)
+(provide 'sage-shell-blocks)
 
 ;;; sage-blocks.el ends here


### PR DESCRIPTION
This pull request adds some simple functions to `sage-shell-mode` and `sage-shell:sage-mode` to accommodate convenient workflow when structuring experimental code in "sheets" of blocks, similar to how one works with cells in a Jupyter Notebook.

The use case is as follows: a user creates a "sheet" file, e.g. `experiment.sage` with blocks of code which represents both his library code as well as his experiments:

```
### Implement the new algorithm
def new_algo(x, y):
    return x + y

def random_input():
    return 7

### Check the new algorithm on small input
print new_algo(1, 2)

### Check the new algorithm on big input
def construct_my_big_number():
    return 100
print new_algo(construct_my_big_number(), 3)

### Check on some random input
print new_algo(random_input() , random_input())
```

In this case `load(experiment.sage)` is not a good alternative to the way one works with the Jupyter Notebook: rather, you want to evaluate the code block by block.

This pull request gives a few functions: `sage-shell-blocks:forward` and `sage-shell-blocks:backward` to move according to the delimiter `###` (which can be changed). It also provides the function  `sage-shell-blocks:send-current` which sends the region delimited by the previos `###` and the following `###`.

If my cursor is in the body of `new_algo`, then `sage-shell-blocks:send-current` would send the defs of `new_algo` and `random_input` to the Sage shell. Furthermore, it would print the "title" of the block:

```
sage: load('/tmp/sage_shell_mode3946wC1/sage_shell_mode_temp.sage')
--- Implement the new algorithm ---
sage:
```

The cursor has moved to the end of the sent block, and calling
`sage-shell-blocks:send-current` again will send the next block.

A last function is `sage-shell-blocks:pull-next` for `sage-shell-mode` to "pull" the next block from the last visited `sage-shell:sage-mode` file. This is a convenient shorthand for visiting that file yourself and sending the block.

By default, I've not set `sage-shell-blocks.el` to be included; the user has to add `(request sage-shell-blocks)` to his `.emacs`.