### PR TITLE
Add "blocks" movement and send functions, rebased

### DIFF
--- a/README.org
+++ b/README.org
@@ -292,7 +292,7 @@ sage: G.charpoly??
 ** Emulating Worksheets: code blocks
 
 Worksheets is a popular paradigm for structuring experiments in computer algebra systems, seen in Jupyter, the Sage Notebook, Maple and many other softwares.
-`sage-shell-mode` supports a lightweight type of this workflow using "code blocks".
+=sage-shell-mode= supports a lightweight type of this workflow using "code blocks".
 
 Essentially, you structure your source file in logical blocks of code, representing both your library code and your experiments.
 For instance:
@@ -321,32 +321,33 @@ assert my_new_algorithm(a, b) == my_new_algorithm(b, a)
 
 #+END_SRC
 
-The blocks of code are logically delimited by lines starting with `###`.
-In this case `load(experiment.sage)` is not a good alternative to the way one works with the Jupyter Notebook: rather, you want to evaluate the code block by block.
+The blocks of code are logically delimited by lines starting with =###=.
+In this case =load(experiment.sage)= is not a good alternative to the way one works with the Jupyter Notebook: rather, you want to evaluate the code block by block.
 You also want to be able to modifying an earlier or later block, run that, and then return to the block in the middle, etc.
 
-`sage-shell-mode` comes with a small set of functions for accommodating this. In `sage-shell:sage-mode`, the following functions are provided:
+=sage-shell-mode= comes with a small set of functions for accommodating this. In =sage-shell:sage-mode=, the following functions are provided:
 
    | Key        | Command                        | Description                                                       |
    |------------+--------------------------------+-------------------------------------------------------------------|
-   | C-M-{      | sage-shell-blocks:backward     | Move backward one block, i.e. to previous `###` delimiter.        |
-   | C-M-}      | sage-shell-blocks:forward      | Move forward one block, i.e. to next `###` delimiter.             |
+   | C-M-{      | sage-shell-blocks:backward     | Move backward one block, i.e. to previous =###= delimiter.        |
+   | C-M-}      | sage-shell-blocks:forward      | Move forward one block, i.e. to next =###= delimiter.             |
    | C-<return> | sage-shell-blocks:send-current | Send the block that the point is currently in to the Sage process |
 
 In the Sage process buffer, the following functions are provided:
 
    | Key        | Command                     | Description                                                |
    |------------+-----------------------------+------------------------------------------------------------|
-   | C-<return> | sage-shell-blocks:pull-next | Take the block from the last visited `sage-shell:sage-mode` buffer and send to the Sage process. |
+   | C-<return> | sage-shell-blocks:pull-next | Take the block from the last visited =sage-shell:sage-mode= buffer and send to the Sage process. |
 
-As an example, if the point is in the body of `my_new_algorithm`, then `C-<return>` (or `M-x sage-shell-blocks:send-current`) would send the definitions of `my_helper` and `my_new_algorithm` to the Sage shell. Furthermore, it would print the "title" of the block:
+As an example, if the point is in the body of =my_new_algorithm=, then =C-<return>= (or =M-x sage-shell-blocks:send-current=) would send the definitions of =my_helper= and =my_new_algorithm= to the Sage shell. Furthermore, it would print the "title" of the block:
 
-```
+#+BEGIN_SRC python
 sage: load('/tmp/sage_shell_mode3946wC1/sage_shell_mode_temp.sage')
 --- Implement the new algorithm ---
 sage:
-```
-The delimiter `###` can be changed by `setq` the variable `sage-shell-blocs:delimiter`.
+#+END_SRC
+
+The delimiter =###= can be changed by =setq= the variable =sage-shell-blocs:delimiter=.
 
 ** SageTeX
 

--- a/README.org
+++ b/README.org
@@ -289,6 +289,65 @@ sage: G.charpoly??
   The file name in the above line is the path for storing the inputs and you can
   change it to what you prefer.
 
+** Emulating Worksheets: code blocks
+
+Worksheets is a popular paradigm for structuring experiments in computer algebra systems, seen in Jupyter, the Sage Notebook, Maple and many other softwares.
+`sage-shell-mode` supports a lightweight type of this workflow using "code blocks".
+
+Essentially, you structure your source file in logical blocks of code, representing both your library code and your experiments.
+For instance:
+
+#+BEGIN_SRC python
+### Implement the new algorithm
+def my_helper(a):
+    return a*2
+
+def my_new_algorithm(x, y):
+    return my_helper(x) + my_helper(y)
+
+
+### Check the new algorithm on small input
+print my_new_algorithm(1, 2)
+
+### Check the new algorithm on big input
+print my_new_algorithm(100, 300)
+
+### Check that my algorithm is commutative using random input
+def my_random_number():
+    return randint(100, 200)
+
+a, b = random_input(), random_input()
+assert my_new_algorithm(a, b) == my_new_algorithm(b, a)
+
+#+END_SRC
+
+The blocks of code are logically delimited by lines starting with `###`.
+In this case `load(experiment.sage)` is not a good alternative to the way one works with the Jupyter Notebook: rather, you want to evaluate the code block by block.
+You also want to be able to modifying an earlier or later block, run that, and then return to the block in the middle, etc.
+
+`sage-shell-mode` comes with a small set of functions for accommodating this. In `sage-shell:sage-mode`, the following functions are provided:
+
+   | Key        | Command                        | Description                                                       |
+   |------------+--------------------------------+-------------------------------------------------------------------|
+   | C-M-{      | sage-shell-blocks:backward     | Move backward one block, i.e. to previous `###` delimiter.        |
+   | C-M-}      | sage-shell-blocks:forward      | Move forward one block, i.e. to next `###` delimiter.             |
+   | C-<return> | sage-shell-blocks:send-current | Send the block that the point is currently in to the Sage process |
+
+In the Sage process buffer, the following functions are provided:
+
+   | Key        | Command                     | Description                                                |
+   |------------+-----------------------------+------------------------------------------------------------|
+   | C-<return> | sage-shell-blocks:pull-next | Take the block from the last visited `sage-shell:sage-mode` buffer and send to the Sage process. |
+
+As an example, if the point is in the body of `my_new_algorithm`, then `C-<return>` (or `M-x sage-shell-blocks:send-current`) would send the definitions of `my_helper` and `my_new_algorithm` to the Sage shell. Furthermore, it would print the "title" of the block:
+
+```
+sage: load('/tmp/sage_shell_mode3946wC1/sage_shell_mode_temp.sage')
+--- Implement the new algorithm ---
+sage:
+```
+The delimiter `###` can be changed by `setq` the variable `sage-shell-blocs:delimiter`.
+
 ** SageTeX
 
 =sage-shell-mode= can be conveniently used when writing Sage-powered LaTeX files

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -1,0 +1,133 @@
+;;; sage-blocks.el --- Support for structuring Sage code in sheets
+
+;; Copyright (C) 2013 Johan S. R. Nielsen
+
+;; Author: Johan S. R. Nielsen <jsrn@jsrn.dk>
+;; Keywords: sage
+
+;;; Commentary:
+
+;; This file adds functionality which supports structuring experimental Sage
+;; code in "sheets", where the code is bundled in "blocks" akin to the boxes of
+;; the Notebook. The core is concerned with convenient handling of such
+;; blocks. The file injects a few keybindings into `sage-mode' as well as
+;; `inferior-sage-mode'.
+
+;; A block is defined by a line beginning with `sage-block-delimiter'.
+
+;;; Code:
+(defcustom sage-block-delimiter "###"
+  "Any line matching the regular expression `sage-block-delimiter' at the
+  beginning of the line is considered a start of a block.
+
+Note that '^' to match at the beginning of the line should not be added to
+`sage-block-delimiter'.
+Strange behaviour might arise if `sage-block-delimiter' matches multiple lines
+at a time."
+  :type 'string
+  :group 'sage)
+
+(defcustom sage-block-title-decorate " ---- "
+  "When printing titles of blocks, put this decoration around the
+title for easy recognition"
+  :type 'string
+  :group 'sage)
+
+;;
+;; Functionality for Sage source files
+;;
+(defun sage-backward-block (arg)
+  "Move backwards to the last beginning of a block."
+  (interactive "p")
+  (if (< arg 0)
+      (sage-forward-block (- arg))
+    (while (and (> arg 0)
+		(search-backward-regexp (concat "^" sage-block-delimiter) nil 'move))
+      (setq arg (- arg 1)))))
+
+(defun sage-forward-block (arg)
+  "Move forwards to the next beginning of a block."
+  (interactive "p")
+  (if (< arg 0)
+      (sage-backward-block (- arg))
+    ;; If point is on a delimiter, we should skip this, so search from beginning of
+    ;; next line (this will match immediately, if next line is a delimiter)
+    (let ((re  (concat "^" sage-block-delimiter)))
+      (when (looking-at re)
+	(forward-line))
+      ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
+      (while (and (> arg 0)
+		  (search-forward-regexp re nil 'move))
+	(setq arg (- arg 1)))
+      ;; We successfully found something so move to the beginning of the match
+      (when (= arg 0)
+	(goto-char (match-beginning 0))))))
+
+(defun sage-send-current-block ()
+  "Send the block that the point is currently in to the inferior shell.
+Move to end of block sent."
+  (interactive)
+  ;; Border-case: if we're standing on a delimiter, sage-backward-block will go
+  ;; to previous delimiter, but we should send from this delimiter and forwards.
+  (sage-forward-block 1)
+  (let* ((this-buf (current-buffer))
+	 (enddelim (point))
+	 (backdelim (save-excursion
+		      (sage-backward-block 1)
+		      (point)))
+	 title)
+    ;; Copy the region to a temp buffer.
+    ;; Possibly change the first line if it contains a title
+    (with-temp-buffer
+      (insert-buffer-substring this-buf backdelim enddelim)
+      (goto-char (point-min))
+      (when (looking-at sage-block-delimiter)
+	(progn
+	  (goto-char (match-end 0))
+	  (setq title (buffer-substring (point)
+					(progn (end-of-line) (point))))
+	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
+	    (setq title (match-string 1 title)))
+	  (unless (equal title "")
+	    (insert (concat "\nprint(\"" sage-block-title-decorate title sage-block-title-decorate "\")")))))
+      (sage-send-region (point-min) (point-max)))))
+
+(defun sage-blocks-default-keybindings ()
+  "Bind default keys for working with sage blocks.
+
+These are
+  C-M-{      `sage-backward-block'
+  C-M-}      `sage-forward-block'
+  C-<return> `sage-send-current-block'
+
+in `sage-mode' and in `inferior-sage-mode-map':
+
+  C-<return> `sage-pull-next-block'"
+  (define-key sage-mode-map (kbd "C-<return>") 'sage-send-current-block)
+  (define-key sage-mode-map (kbd "C-M-{")        'sage-backward-block)
+  (define-key sage-mode-map (kbd "C-M-}")        'sage-forward-block)
+  (define-key inferior-sage-mode-map (kbd "C-<return>") 'sage-pull-next-block))
+
+;;
+;; Functionality for the inferior shell
+;;
+(defun sage-pull-next-block ()
+  "Evaluate the next block of the last visited file in Sage mode."
+  (interactive)
+  ;; Find the first buffer in buffer-list which is in sage-mode
+  (let* ((lst (buffer-list))
+	 (buf
+	  (catch 'break
+	    (while lst
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-mode))
+		  (throw 'break (car lst))
+		(setq lst (cdr lst)))))))
+    (if buf
+	(progn
+	  (switch-to-buffer-other-window buf)
+	  (sage-send-current-block))
+      (error "No sage-mode buffer found"))))
+
+(provide 'sage-blocks)
+
+;;; sage-blocks.el ends here

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -25,13 +25,13 @@ Note that '^' to match at the beginning of the line should not be added to
 Strange behaviour might arise if `sage-shell-blocks:delimiter' matches multiple lines
 at a time."
   :type 'string
-  :group 'sage)
+  :group 'sage-shell)
 
 (defcustom sage-shell-blocks:title-decorate " ---- "
   "When printing titles of blocks, put this decoration around the
 title for easy recognition"
   :type 'string
-  :group 'sage)
+  :group 'sage-shell)
 
 ;;
 ;; Functionality for Sage source files

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -3,14 +3,29 @@
 ;; Copyright (C) 2013-2016 Johan Rosenkilde
 
 ;; Author: Johan Rosenkilde <jsrn@jsrn.dk>
-;; Keywords: sage
+;; URL: https://github.com/stakemori/sage-shell-mode
+;; Keywords: Sage, math
+
+;;; License
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
 ;; This file adds functionality which supports structuring experimental Sage
 ;; code in "sheets", where the code is bundled in "blocks" akin to the boxes of
 ;; the Notebook. Functions are provided for convenient handling of such blocks.
-;; The file injects a few keybindings into `sage-mode' as well as
+;; The file injects a few keybindings into `sage-shell:sage-mode' as well as
 ;; `sage-shell-mode'.
 
 ;; A block is defined by a line beginning with `sage-shell-blocks:delimiter'.

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -13,21 +13,21 @@
 ;; The file injects a few keybindings into `sage-mode' as well as
 ;; `sage-shell-mode'.
 
-;; A block is defined by a line beginning with `sage-shell:block-delimiter'.
+;; A block is defined by a line beginning with `sage-shell-blocks:delimiter'.
 
 ;;; Code:
-(defcustom sage-shell:block-delimiter "###"
-  "Any line matching the regular expression `sage-shell:block-delimiter' at the
+(defcustom sage-shell-blocks:delimiter "###"
+  "Any line matching the regular expression `sage-shell-blocks:delimiter' at the
   beginning of the line is considered a start of a block.
 
 Note that '^' to match at the beginning of the line should not be added to
-`sage-shell:block-delimiter'.
-Strange behaviour might arise if `sage-shell:block-delimiter' matches multiple lines
+`sage-shell-blocks:delimiter'.
+Strange behaviour might arise if `sage-shell-blocks:delimiter' matches multiple lines
 at a time."
   :type 'string
   :group 'sage)
 
-(defcustom sage-shell:block-title-decorate " ---- "
+(defcustom sage-shell-blocks:title-decorate " ---- "
   "When printing titles of blocks, put this decoration around the
 title for easy recognition"
   :type 'string
@@ -36,23 +36,23 @@ title for easy recognition"
 ;;
 ;; Functionality for Sage source files
 ;;
-(defun sage-shell:backward-block (arg)
+(defun sage-shell-blocks:backward (arg)
   "Move backwards to the last beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-shell:forward-block (- arg))
+      (sage-shell-blocks:forward (- arg))
     (while (and (> arg 0)
-		(search-backward-regexp (concat "^" sage-shell:block-delimiter) nil 'move))
+		(search-backward-regexp (concat "^" sage-shell-blocks:delimiter) nil 'move))
       (setq arg (- arg 1)))))
 
-(defun sage-shell:forward-block (arg)
+(defun sage-shell-blocks:forward (arg)
   "Move forwards to the next beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-shell:backward-block (- arg))
+      (sage-shell-blocks:backward (- arg))
     ;; If point is on a delimiter, we should skip this, so search from beginning of
     ;; next line (this will match immediately, if next line is a delimiter)
-    (let ((re  (concat "^" sage-shell:block-delimiter)))
+    (let ((re  (concat "^" sage-shell-blocks:delimiter)))
       (when (looking-at re)
 	(forward-line))
       ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
@@ -63,17 +63,17 @@ title for easy recognition"
       (when (= arg 0)
 	(goto-char (match-beginning 0))))))
 
-(defun sage-shell:send-current-block ()
+(defun sage-shell-blocks:send-current ()
   "Send the block that the point is currently in to the inferior shell.
 Move to end of block sent."
   (interactive)
-  ;; Border-case: if we're standing on a delimiter, sage-shell:backward-block will go
+  ;; Border-case: if we're standing on a delimiter, sage-shell-blocks:backward will go
   ;; to previous delimiter, but we should send from this delimiter and forwards.
-  (sage-shell:forward-block 1)
+  (sage-shell-blocks:forward 1)
   (let* ((this-buf (current-buffer))
 	 (enddelim (point))
 	 (backdelim (save-excursion
-		      (sage-shell:backward-block 1)
+		      (sage-shell-blocks:backward 1)
 		      (point)))
 	 title)
     ;; Copy the region to a temp buffer.
@@ -81,7 +81,7 @@ Move to end of block sent."
     (with-temp-buffer
       (insert-buffer-substring this-buf backdelim enddelim)
       (goto-char (point-min))
-      (when (looking-at sage-shell:block-delimiter)
+      (when (looking-at sage-shell-blocks:delimiter)
 	(progn
 	  (goto-char (match-end 0))
 	  (setq title (buffer-substring (point)
@@ -89,43 +89,42 @@ Move to end of block sent."
 	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
 	    (setq title (match-string 1 title)))
 	  (unless (equal title "")
-	    (insert (concat "\nprint(\"" sage-shell:block-title-decorate title sage-shell:block-title-decorate "\")")))))
-      (sage-shell:send-region (point-min) (point-max)))))
+	    (insert (concat "\nprint(\"" sage-shell-blocks:title-decorate title sage-shell-blocks:title-decorate "\")")))))
+      (sage-shell-edit:send-region (point-min) (point-max)))))
 
-(defun sage-shell:blocks-default-keybindings ()
+(defun sage-shell-blocks:default-keybindings ()
   "Bind default keys for working with Sage blocks.
 
-The following are added to `sage-mode':
-  C-M-{      `sage-shell:backward-block'
-  C-M-}      `sage-shell:forward-block'
-  C-<return> `sage-shell:send-current-block'
+The following are added to `sage-shell:sage-mode':
+  C-M-{      `sage-shell-blocks:backward'
+  C-M-}      `sage-shell-blocks:forward'
+  C-<return> `sage-shell-blocks:send-current'
 
 The following are added to `sage-shell-mode':
-  C-<return> `sage-shell:pull-next-block'"
-  (define-key sage-shell:mode-map (kbd "C-<return>") 'sage-shell:send-current-block)
-  (define-key sage-shell:mode-map (kbd "C-M-{")        'sage-shell:backward-block)
-  (define-key sage-shell:mode-map (kbd "C-M-}")        'sage-shell:forward-block)
-  (define-key inferior-sage-shell:mode-map (kbd "C-<return>") 'sage-shell:pull-next-block))
+  C-<return> `sage-shell-blocks:pull-next'"
+  (define-key sage-shell:sage-mode-map (kbd "C-<return>") 'sage-shell-blocks:send-current)
+  (define-key sage-shell:sage-mode-map (kbd "C-M-{")      'sage-shell-blocks:backward)
+  (define-key sage-shell:sage-mode-map (kbd "C-M-}")      'sage-shell-blocks:forward)
+  (define-key sage-shell-mode-map (kbd "C-<return>")      'sage-shell-blocks:pull-next))
 
-;;
 ;; Functionality for the inferior shell
 ;;
-(defun sage-shell:pull-next-block ()
+(defun sage-shell-blocks:pull-next ()
   "Evaluate the next block of the last visited file in Sage mode."
   (interactive)
-  ;; Find the first buffer in buffer-list which is in sage-shell-mode
+  ;; Find the first buffer in buffer-list which is in sage-shell:sage-mode
   (let* ((lst (buffer-list))
 	 (buf
 	  (catch 'break
 	    (while lst
-	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell-mode))
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell:sage-mode))
 		  (throw 'break (car lst))
 		(setq lst (cdr lst)))))))
     (if buf
 	(progn
 	  (switch-to-buffer-other-window buf)
-	  (sage-shell:send-current-block))
-      (error "No sage-shell-mode buffer found"))))
+	  (sage-shell-blocks:send-current))
+      (error "No sage-shell:sage-mode buffer found"))))
 
 (provide 'sage-shell-blocks)
 

--- a/sage-shell-blocks.el
+++ b/sage-shell-blocks.el
@@ -1,33 +1,33 @@
-;;; sage-blocks.el --- Support for structuring Sage code in sheets
+;;; sage-shell-blocks.el --- Support for structuring Sage code in sheets
 
-;; Copyright (C) 2013 Johan S. R. Nielsen
+;; Copyright (C) 2013-2016 Johan Rosenkilde
 
-;; Author: Johan S. R. Nielsen <jsrn@jsrn.dk>
+;; Author: Johan Rosenkilde <jsrn@jsrn.dk>
 ;; Keywords: sage
 
 ;;; Commentary:
 
 ;; This file adds functionality which supports structuring experimental Sage
 ;; code in "sheets", where the code is bundled in "blocks" akin to the boxes of
-;; the Notebook. The core is concerned with convenient handling of such
-;; blocks. The file injects a few keybindings into `sage-mode' as well as
-;; `inferior-sage-mode'.
+;; the Notebook. Functions are provided for convenient handling of such blocks.
+;; The file injects a few keybindings into `sage-mode' as well as
+;; `sage-shell-mode'.
 
-;; A block is defined by a line beginning with `sage-block-delimiter'.
+;; A block is defined by a line beginning with `sage-shell:block-delimiter'.
 
 ;;; Code:
-(defcustom sage-block-delimiter "###"
-  "Any line matching the regular expression `sage-block-delimiter' at the
+(defcustom sage-shell:block-delimiter "###"
+  "Any line matching the regular expression `sage-shell:block-delimiter' at the
   beginning of the line is considered a start of a block.
 
 Note that '^' to match at the beginning of the line should not be added to
-`sage-block-delimiter'.
-Strange behaviour might arise if `sage-block-delimiter' matches multiple lines
+`sage-shell:block-delimiter'.
+Strange behaviour might arise if `sage-shell:block-delimiter' matches multiple lines
 at a time."
   :type 'string
   :group 'sage)
 
-(defcustom sage-block-title-decorate " ---- "
+(defcustom sage-shell:block-title-decorate " ---- "
   "When printing titles of blocks, put this decoration around the
 title for easy recognition"
   :type 'string
@@ -36,23 +36,23 @@ title for easy recognition"
 ;;
 ;; Functionality for Sage source files
 ;;
-(defun sage-backward-block (arg)
+(defun sage-shell:backward-block (arg)
   "Move backwards to the last beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-forward-block (- arg))
+      (sage-shell:forward-block (- arg))
     (while (and (> arg 0)
-		(search-backward-regexp (concat "^" sage-block-delimiter) nil 'move))
+		(search-backward-regexp (concat "^" sage-shell:block-delimiter) nil 'move))
       (setq arg (- arg 1)))))
 
-(defun sage-forward-block (arg)
+(defun sage-shell:forward-block (arg)
   "Move forwards to the next beginning of a block."
   (interactive "p")
   (if (< arg 0)
-      (sage-backward-block (- arg))
+      (sage-shell:backward-block (- arg))
     ;; If point is on a delimiter, we should skip this, so search from beginning of
     ;; next line (this will match immediately, if next line is a delimiter)
-    (let ((re  (concat "^" sage-block-delimiter)))
+    (let ((re  (concat "^" sage-shell:block-delimiter)))
       (when (looking-at re)
 	(forward-line))
       ;; search forward: if it worked, move to begin of delimiter, otherwise end of file
@@ -63,17 +63,17 @@ title for easy recognition"
       (when (= arg 0)
 	(goto-char (match-beginning 0))))))
 
-(defun sage-send-current-block ()
+(defun sage-shell:send-current-block ()
   "Send the block that the point is currently in to the inferior shell.
 Move to end of block sent."
   (interactive)
-  ;; Border-case: if we're standing on a delimiter, sage-backward-block will go
+  ;; Border-case: if we're standing on a delimiter, sage-shell:backward-block will go
   ;; to previous delimiter, but we should send from this delimiter and forwards.
-  (sage-forward-block 1)
+  (sage-shell:forward-block 1)
   (let* ((this-buf (current-buffer))
 	 (enddelim (point))
 	 (backdelim (save-excursion
-		      (sage-backward-block 1)
+		      (sage-shell:backward-block 1)
 		      (point)))
 	 title)
     ;; Copy the region to a temp buffer.
@@ -81,7 +81,7 @@ Move to end of block sent."
     (with-temp-buffer
       (insert-buffer-substring this-buf backdelim enddelim)
       (goto-char (point-min))
-      (when (looking-at sage-block-delimiter)
+      (when (looking-at sage-shell:block-delimiter)
 	(progn
 	  (goto-char (match-end 0))
 	  (setq title (buffer-substring (point)
@@ -89,45 +89,44 @@ Move to end of block sent."
 	  (when (string-match "^ *\\([^ ].*[^ ]\\) *$" title)
 	    (setq title (match-string 1 title)))
 	  (unless (equal title "")
-	    (insert (concat "\nprint(\"" sage-block-title-decorate title sage-block-title-decorate "\")")))))
-      (sage-send-region (point-min) (point-max)))))
+	    (insert (concat "\nprint(\"" sage-shell:block-title-decorate title sage-shell:block-title-decorate "\")")))))
+      (sage-shell:send-region (point-min) (point-max)))))
 
-(defun sage-blocks-default-keybindings ()
-  "Bind default keys for working with sage blocks.
+(defun sage-shell:blocks-default-keybindings ()
+  "Bind default keys for working with Sage blocks.
 
-These are
-  C-M-{      `sage-backward-block'
-  C-M-}      `sage-forward-block'
-  C-<return> `sage-send-current-block'
+The following are added to `sage-mode':
+  C-M-{      `sage-shell:backward-block'
+  C-M-}      `sage-shell:forward-block'
+  C-<return> `sage-shell:send-current-block'
 
-in `sage-mode' and in `inferior-sage-mode-map':
-
-  C-<return> `sage-pull-next-block'"
-  (define-key sage-mode-map (kbd "C-<return>") 'sage-send-current-block)
-  (define-key sage-mode-map (kbd "C-M-{")        'sage-backward-block)
-  (define-key sage-mode-map (kbd "C-M-}")        'sage-forward-block)
-  (define-key inferior-sage-mode-map (kbd "C-<return>") 'sage-pull-next-block))
+The following are added to `sage-shell-mode':
+  C-<return> `sage-shell:pull-next-block'"
+  (define-key sage-shell:mode-map (kbd "C-<return>") 'sage-shell:send-current-block)
+  (define-key sage-shell:mode-map (kbd "C-M-{")        'sage-shell:backward-block)
+  (define-key sage-shell:mode-map (kbd "C-M-}")        'sage-shell:forward-block)
+  (define-key inferior-sage-shell:mode-map (kbd "C-<return>") 'sage-shell:pull-next-block))
 
 ;;
 ;; Functionality for the inferior shell
 ;;
-(defun sage-pull-next-block ()
+(defun sage-shell:pull-next-block ()
   "Evaluate the next block of the last visited file in Sage mode."
   (interactive)
-  ;; Find the first buffer in buffer-list which is in sage-mode
+  ;; Find the first buffer in buffer-list which is in sage-shell-mode
   (let* ((lst (buffer-list))
 	 (buf
 	  (catch 'break
 	    (while lst
-	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-mode))
+	      (if (with-current-buffer (car lst) (derived-mode-p 'sage-shell-mode))
 		  (throw 'break (car lst))
 		(setq lst (cdr lst)))))))
     (if buf
 	(progn
 	  (switch-to-buffer-other-window buf)
-	  (sage-send-current-block))
-      (error "No sage-mode buffer found"))))
+	  (sage-shell:send-current-block))
+      (error "No sage-shell-mode buffer found"))))
 
-(provide 'sage-blocks)
+(provide 'sage-shell-blocks)
 
 ;;; sage-blocks.el ends here


### PR DESCRIPTION
I rebased the commits on fix-branch and opened a new pull request for this reason replacing #14. Sorry for the mess.

I wrote a README for the functionality, fixed the license and the group keyword. I wrote the README as if `sage-shell-blocks` is automatically loaded with  `sage-shell-mode`, but I did not change any loading, as you mentioned you wanted to do some modifications here. Feel free to just plug in the entire `sage-shell-blocks.el` into `sage-shell-mode.el` if that is easier!

Best,
Johan